### PR TITLE
Heroes support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,6 @@ keep-inventory: true
 keep-xp: true
 xp-to-remove: 0
 my-pet-enabled: false
-heroes-enabled: false
 check-for-updates: true
 events:
     other:

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: iRestore
 main: com.github.triarry.iRestore.iRestore
 version: 1.5.2
 author: triarry
-softdepend: [Vault, MyPet, Heroes]
+softdepend: [Vault, MyPet]
 commands:
     irestore:
         description: Tells the player information about this plugin.

--- a/src/com/github/triarry/iRestore/iRestore.java
+++ b/src/com/github/triarry/iRestore/iRestore.java
@@ -79,16 +79,6 @@ public class iRestore extends JavaPlugin {
             }
         }
         
-        if (getConfig().getBoolean("heroes-enabled")) {
-            if (!setupHeroes()) {
-                this.getLogger().info("Heroes not found! Disabling Heroes stuff.");
-            }
-            
-            else {
-            	this.getLogger().info("iRestore has hooked into Heroes!");
-            }
-        }
-        
 		if(getConfig().getBoolean("check-for-updates")) {
 			Updater updater = new Updater(this, "irestore", this.getFile(), Updater.UpdateType.NO_DOWNLOAD, false);
 			updater.getResult();
@@ -135,15 +125,6 @@ public class iRestore extends JavaPlugin {
     private boolean setupMyPet() {
         if (getServer().getPluginManager().isPluginEnabled("MyPet")) {
             myPetEnabled = true;
-            return true;
-        }
-        
-        return false;
-    }
-    
-    private boolean setupHeroes() {
-        if (getServer().getPluginManager().isPluginEnabled("Heroes")) {
-            HeroesEnabled = true;
             return true;
         }
         

--- a/src/com/github/triarry/iRestore/listeners/PlayerListener.java
+++ b/src/com/github/triarry/iRestore/listeners/PlayerListener.java
@@ -6,7 +6,6 @@ import de.Keyle.MyPet.skill.skills.implementation.ranged.MyPetProjectile;
 
 import com.github.triarry.iRestore.iRestore;
 import com.github.triarry.iRestore.utilities.Utilities;
-import com.herocraftonline.heroes.characters.skill.Skill;
 
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -82,8 +81,6 @@ public class PlayerListener implements Listener {
         Player p = event.getEntity();
         String killer;
         EntityDamageEvent pDamage = event.getEntity().getLastDamageCause();
-        org.bukkit.entity.Entity attacker;
-        Skill skill;
         
         if(p.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
             EntityDamageByEntityEvent lastDamageEvent = (EntityDamageByEntityEvent) p.getLastDamageCause();
@@ -157,19 +154,27 @@ public class PlayerListener implements Listener {
              */
             
             else if(lastDamageEvent.getCause() == DamageCause.MAGIC) {
-            	ThrownPotion a = (ThrownPotion) lastDamageEvent.getDamager();
-            	
-            	if(a.getShooter() instanceof Witch && (config.getBoolean("events.mobs.witch") || config.getBoolean("events.mobs.all")) && p.hasPermission("irestore.events.mobs.witch")) {
-            		killer = "Witch";
-            	}
-            	
-            	else if(a.getShooter() instanceof Player && (config.getBoolean("events.pvp.potions") || config.getBoolean("events.pvp.all")) && p.hasPermission("irestore.events.pvp.potion")) {
-            		Player s = (Player) a.getShooter();
-            		killer = s.getName();
-            	}
-            	
-            	else {
-            		return;
+            	try {
+                	ThrownPotion a = (ThrownPotion) lastDamageEvent.getDamager();
+                	
+                	if(a.getShooter() instanceof Witch && (config.getBoolean("events.mobs.witch") || config.getBoolean("events.mobs.all")) && p.hasPermission("irestore.events.mobs.witch")) {
+                		killer = "Witch";
+                	}
+                	
+                	else if(a.getShooter() instanceof Player && (config.getBoolean("events.pvp.potions") || config.getBoolean("events.pvp.all")) && p.hasPermission("irestore.events.pvp.potion")) {
+                		Player s = (Player) a.getShooter();
+                		killer = s.getName();
+                	}
+                	else {
+                		return;
+                	}
+            	} catch (ClassCastException e) {
+            		if ((config.getBoolean("events.pvp.skills") || config.getBoolean("events.pvp.all")) && p.hasPermission("irestore.events.pvp.potion")) {
+                		killer = p.getDisplayName() + "'s skill";
+            		} 
+            		else {
+            			return;
+            		}
             	}
             }
             
@@ -290,11 +295,6 @@ public class PlayerListener implements Listener {
             
             else if ((p.getKiller() != null || lastDamageEvent.getDamager() instanceof Player) && (config.getBoolean("events.pvp.melee") || config.getBoolean("events.pvp.all")) && p.hasPermission("irestore.events.pvp.melee")) { 
             	killer = p.getKiller().getName();
-            }
-            
-            
-            else if (lastDamageEvent.getAttacker() == skill && (config.getBoolean("events.pvp.skillHeroes") || config.getBoolean("events.pvp.all")) && p.hasPermission("irestore.events.other.skillHeroes")) {
-            	killer = p.getKiller().getName() + "'s skill";
             }
             
             /*
@@ -548,6 +548,7 @@ public class PlayerListener implements Listener {
 		}
 	}
 	
+	@SuppressWarnings("deprecation")
 	public void dropBlacklist(PlayerDeathEvent event) {
 		FileConfiguration config = plugin.getConfig();
 		Player p = event.getEntity();
@@ -563,6 +564,7 @@ public class PlayerListener implements Listener {
 		event.getDrops().clear();
 	}
 	
+	@SuppressWarnings("deprecation")
 	public void dropWhitelist(PlayerDeathEvent event) {
 		FileConfiguration config = plugin.getConfig();
 		

--- a/src/com/github/triarry/iRestore/utilities/Utilities.java
+++ b/src/com/github/triarry/iRestore/utilities/Utilities.java
@@ -20,6 +20,7 @@ public class Utilities {
         plugin = plug;
     }
     
+	@SuppressWarnings("deprecation")
 	public void blacklistItems(Player p) {
 		if (plugin.getConfig().getBoolean("blacklist.enabled") == true) {
 			for (Integer itemList : plugin.getConfig().getIntegerList("blacklist.items")) {
@@ -52,6 +53,7 @@ public class Utilities {
 		}
 	}
 	
+	@SuppressWarnings("deprecation")
 	public void whitelistItems(Player p) {
 		Boolean itemCheck = false;
 		
@@ -78,6 +80,7 @@ public class Utilities {
 		}
 	}
 	
+	@SuppressWarnings("deprecation")
 	public void whitelistArmor(Player p) {
 		Boolean helmetCheck = false;
 		Boolean chestplateCheck = false;


### PR DESCRIPTION
It was hard but I did it. It not direct compatibility with Heroes but it also give protect for "strange" potions effect, like Heroes skills or (maybe) McMMO skills and other plugins.

Sorry for those unreal additions ad deletes, EGit don't like GitHub. I have added only "skills" to config.yml, SuppressWarnings annotations and change effect of DamageCause.Magic by using try-catch.

I hope that pull request will repair a lot of bugs with other plugins.
